### PR TITLE
Permission issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Once you have pulled the repoistory into your WSL2 environment you have two opti
 
 ### *Option 1:*
 
-This is the preferred option since it gurantees fresh copies of all the dependencies to run the tunnel. 
+This is the preferred option since it gurantees fresh copies of all the dependencies to run the tunnel.
 1. Install Docker Desktop on your windows machine.
 2. run `sudo ./wsl-vpn-setup.sh` from within this folder
 
 
-### *Option 2:*    
+### *Option 2:*
 If you prefer not to install Docker on your windows machine, you can run `sudo ./wsl-vpn-setup-no-docker.sh` which would download the required files.
 
 ## Removal
 
-In case you want to remove or re-install the wsl-vpn files, you can run:
+In case you want to remove and/or re-install the wsl-vpn files, you can run:
 
 1. `sudo ./wsl-vpn-unsetup.sh`
 

--- a/wsl-vpn-setup.sh
+++ b/wsl-vpn-setup.sh
@@ -21,11 +21,11 @@ function ppid() {
 
 DOCKER_WSL="/mnt/c/Program Files/Docker/Docker/resources"
 
-for cmd in socat unzip isoinfo wget p7zip; do
+for cmd in socat unzip isoinfo p7zip; do
     if ! command -v "${cmd}" &> /dev/null; then
         # Warning: Specific to debian/ubuntu
         apt update
-        apt install -y socat unzip p7zip genisoimage wget
+        apt install -y socat unzip p7zip genisoimage
         break
     fi
 done
@@ -46,7 +46,6 @@ touch /etc/sudoers.d/wsl-vpnkit
 write_to_file "${SUDO_USER} ALL=(ALL) NOPASSWD: /usr/sbin/service wsl-vpnkit *" /etc/sudoers.d/wsl-vpnkit
 chown root:root /etc/sudoers.d/wsl-vpnkit
 
-cd ~
 mkdir -p /mnt/c/bin
 cp "${DOCKER_WSL}/vpnkit.exe" /mnt/c/bin/wsl-vpnkit.exe
 
@@ -55,7 +54,9 @@ mv vpnkit-tap-vsockd /sbin/vpnkit-tap-vsockd
 chmod +x /sbin/vpnkit-tap-vsockd
 chown root:root /sbin/vpnkit-tap-vsockd
 
-wget https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip
+# This doesn't require WSL internet to be working. Apparently calling powershell
+# this way writes directly to this same directory
+/mnt/c/WINDOWS/system32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip -OutFile npiperelay_windows_amd64.zip"
 unzip npiperelay_windows_amd64.zip npiperelay.exe
 rm npiperelay_windows_amd64.zip
 mv npiperelay.exe /mnt/c/bin/

--- a/wsl-vpn-setup.sh
+++ b/wsl-vpn-setup.sh
@@ -60,8 +60,10 @@ unzip npiperelay_windows_amd64.zip npiperelay.exe
 rm npiperelay_windows_amd64.zip
 mv npiperelay.exe /mnt/c/bin/
 
-write_to_file "sudo service wsl-vpnkit start"  /etc/profile
-write_to_file "sudo service wsl-vpnkit start"  /etc/zsh/zprofile
+echo "service wsl-vpnkit status > /dev/null || sudo service wsl-vpnkit start" > /etc/profile.d/wsl-vpnkit.sh
+chmod 644 /etc/profile.d/wsl-vpnkit.sh
+chown root:root /etc/profile.d/wsl-vpnkit.sh
+write_to_file "service wsl-vpnkit status > /dev/null || sudo service wsl-vpnkit start"  /etc/zsh/zprofile
 
 if [ -e "/etc/wsl.conf" ]; then
     cp /etc/wsl.conf /etc/.wsl.conf.orig
@@ -69,12 +71,16 @@ else
     touch /etc/.wsl.conf.orig
 fi
 
+if [ -L /etc/resolv.conf ]; then
+  unlink /etc/resolv.conf
+fi
+
 if ! grep "^generateResolvConf = false" /etc/wsl.conf &> /dev/null; then
     if ! grep "^\[network\]" /etc/wsl.conf &> /dev/null; then
-      # append to end of the file, always makes it its own line
-      sed -i '$a[network]' /etc/wsl.conf
+        # append to end of the file, always makes it its own line
+        sed -i '$a[network]' /etc/wsl.conf
     fi
     sed -i 's|^\[network\].*|&\ngenerateResolvConf = false|' /etc/wsl.conf
 fi
 
-echo "Setup"
+echo "Setup complete"

--- a/wsl-vpn-setup.sh
+++ b/wsl-vpn-setup.sh
@@ -18,7 +18,7 @@ function write_to_file() {
 DOCKER_WSL="/mnt/c/Program Files/Docker/Docker/resources"
 
 for cmd in socat unzip isoinfo wget p7zip; do
-    if ! command -v "${cmd}" &> /dev/nul; then
+    if ! command -v "${cmd}" &> /dev/null; then
         # Warning: Specific to debian/ubuntu
         apt update
         apt install -y socat unzip p7zip genisoimage wget

--- a/wsl-vpn-setup.sh
+++ b/wsl-vpn-setup.sh
@@ -63,4 +63,18 @@ mv npiperelay.exe /mnt/c/bin/
 write_to_file "sudo service wsl-vpnkit start"  /etc/profile
 write_to_file "sudo service wsl-vpnkit start"  /etc/zsh/zprofile
 
+if [ -e "/etc/wsl.conf" ]; then
+    cp /etc/wsl.conf /etc/.wsl.conf.orig
+else
+    touch /etc/.wsl.conf.orig
+fi
+
+if ! grep "^generateResolvConf = false" /etc/wsl.conf &> /dev/null; then
+    if ! grep "^\[network\]" /etc/wsl.conf &> /dev/null; then
+      # append to end of the file, always makes it its own line
+      sed -i '$a[network]' /etc/wsl.conf
+    fi
+    sed -i 's|^\[network\].*|&\ngenerateResolvConf = false|' /etc/wsl.conf
+fi
+
 echo "Setup"

--- a/wsl-vpn-setup.sh
+++ b/wsl-vpn-setup.sh
@@ -61,10 +61,10 @@ unzip npiperelay_windows_amd64.zip npiperelay.exe
 rm npiperelay_windows_amd64.zip
 mv npiperelay.exe /mnt/c/bin/
 
-echo "service wsl-vpnkit status > /dev/null || sudo service wsl-vpnkit start" > /etc/profile.d/wsl-vpnkit.sh
+echo "service wsl-vpnkit status > /dev/null || service wsl-vpnkit start" > /etc/profile.d/wsl-vpnkit.sh
 chmod 644 /etc/profile.d/wsl-vpnkit.sh
 chown root:root /etc/profile.d/wsl-vpnkit.sh
-write_to_file "service wsl-vpnkit status > /dev/null || sudo service wsl-vpnkit start"  /etc/zsh/zprofile
+write_to_file "service wsl-vpnkit status > /dev/null || service wsl-vpnkit start"  /etc/zsh/zprofile
 
 if [ -e "/etc/wsl.conf" ]; then
     cp /etc/wsl.conf /etc/.wsl.conf.orig

--- a/wsl-vpn-unsetup.sh
+++ b/wsl-vpn-unsetup.sh
@@ -30,7 +30,7 @@ rm_if /mnt/c/bin/npiperelay.exe
 rm_if /mnt/c/bin/wsl-vpnkit.exe
 rmdir /mnt/c/bin || :
 
-sed_file '/^service wsl-vpnkit start$/d' /etc/profile 
-sed_file '/^service wsl-vpnkit start$/d' /etc/zsh/zprofile
+sed_file '/^sudo service wsl-vpnkit start$/d' /etc/profile
+sed_file '/^sudo service wsl-vpnkit start$/d' /etc/zsh/zprofile
 
 echo "Removed!"

--- a/wsl-vpn-unsetup.sh
+++ b/wsl-vpn-unsetup.sh
@@ -10,7 +10,7 @@ fi
 function sed_file() {
     if [ -e "${2}" ]; then
         sed -i "${1}" "${2}"
-    fi 
+    fi
 }
 
 function rm_if() {
@@ -32,5 +32,13 @@ rmdir /mnt/c/bin || :
 
 sed_file '/^sudo service wsl-vpnkit start$/d' /etc/profile
 sed_file '/^sudo service wsl-vpnkit start$/d' /etc/zsh/zprofile
+
+if [ -e /etc/.wsl.conf.orig ]; then
+    if ! grep -q '^generateResolvConf = false' /etc/.wsl.conf.orig; then
+       sed -i '/^generateResolvConf = false.*/d' /etc/wsl.conf
+    fi
+    rm /etc/.wsl.conf.orig
+fi
+
 
 echo "Removed!"

--- a/wsl-vpn-unsetup.sh
+++ b/wsl-vpn-unsetup.sh
@@ -30,12 +30,15 @@ rm_if /mnt/c/bin/npiperelay.exe
 rm_if /mnt/c/bin/wsl-vpnkit.exe
 rmdir /mnt/c/bin || :
 
-sed_file '/^sudo service wsl-vpnkit start$/d' /etc/profile
-sed_file '/^sudo service wsl-vpnkit start$/d' /etc/zsh/zprofile
+# sed_file '/service wsl-vpnkit start/d' /etc/profile
+rm_if /etc/profile.d/wsl-vpnkit.sh
+sed_file '/service wsl-vpnkit start/d' /etc/zsh/zprofile
 
 if [ -e /etc/.wsl.conf.orig ]; then
     if ! grep -q '^generateResolvConf = false' /etc/.wsl.conf.orig; then
-       sed -i '/^generateResolvConf = false.*/d' /etc/wsl.conf
+        sed -i '/^generateResolvConf = false.*/d' /etc/wsl.conf
+        # On the next restart of wsl, the symlink will be recreated
+        rm /etc/resolv.conf
     fi
     rm /etc/.wsl.conf.orig
 fi

--- a/wsl-vpnkit.service
+++ b/wsl-vpnkit.service
@@ -9,7 +9,6 @@ ret=0
 
 start() {
         # using `wsl.exe` allows the daemon to keep running in the background even when you close your terminal
-        # /mnt/c/WINDOWS/system32/wsl.exe -d "%%WSL_DISTRO_NAME%%" --user $(whoami) -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
         /mnt/c/WINDOWS/system32/wsl.exe -d "%%WSL_DISTRO_NAME%%" --user root -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
         ret=$?
 }

--- a/wsl-vpnkit.service
+++ b/wsl-vpnkit.service
@@ -9,7 +9,8 @@ ret=0
 
 start() {
         # using `wsl.exe` allows the daemon to keep running in the background even when you close your terminal
-        /mnt/c/WINDOWS/system32/wsl.exe --user $(whoami) -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
+        # /mnt/c/WINDOWS/system32/wsl.exe -d "%%WSL_DISTRO_NAME%%" --user $(whoami) -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
+        /mnt/c/WINDOWS/system32/wsl.exe -d "%%WSL_DISTRO_NAME%%" --user root -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
         ret=$?
 }
 


### PR DESCRIPTION
Merge after #1 

I could not get the script working as explained, I had a number of issues

1. My default WSL distro was `docker-desktop`, therefore `wsl` calls were not running in the correct WSL. This would also be a problem once I start running multiple WSLs again
    - I needed the `WSL_DISTRO_NAME`, and I came up with a _creative way_ to automatically extract it. Looking at @sakai135 original documentation, he suggested using `--preserve-env` flag, but I was trying to "K.I.S.S." for the user, so I added a way to extract `WSL_DISTRO_NAME` from the grandparent PID.
2. Removed `wget` in lieu of using Powershell. This has the added benifit that it works while you are on VPN and don't have the VPN fix installed
3. ~I added `sudo` to the `service wsl-vpnkit start` call. As far as I can tell, this was supposed to happen.~
4. I could not get the following to work

    ```
    /mnt/c/WINDOWS/system32/wsl.exe --user $(whoami) -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
    ```

    My user does not have write permission to `/var/run/` or `/var/log/` either. Was I doing something wrong here?

